### PR TITLE
Form fix

### DIFF
--- a/src/assets/css/global.css
+++ b/src/assets/css/global.css
@@ -32,8 +32,13 @@ td {
 }
 
 .error-message {
-	background: red;
-	border: 1px solid black;
-	padding: .125em .125em 0em .5em;
-	font-style: italic;
+	background-color: #d9534f;
+	border: 1px solid #d43f3a;
+	border-radius: .125em;
+	
+	color: #fff;
+	font-weight: bold;
+	padding: .125em;
+	text-align: center;
+
 }

--- a/src/assets/partials/forms/editForm.html
+++ b/src/assets/partials/forms/editForm.html
@@ -27,7 +27,8 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="editForm.first.$dirty && editForm.first.$invalid">
-						<div ng-messages="editForm.first.$error">
+						<div ng-messages="editForm.first.$error"
+							 class="error-message">
 							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>A first name is required</small>
@@ -70,7 +71,8 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="editForm.last.$dirty && editForm.last.$invalid">
-						<div ng-messages="editForm.last.$error">
+						<div ng-messages="editForm.last.$error"
+							 class="error-message">
 							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>A last name is required</small>
@@ -113,14 +115,15 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="editForm.phone.$dirty && editForm.phone.$invalid">
-						<div ng-messages="editForm.phone.$error">
-							<div ng-message="required" class=>
+						<div ng-messages="editForm.phone.$error"
+							 class="error-message">
+							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>An phone number is required.</small>
 							</div>
 							<div ng-message="pattern">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
-								<small>A phone number must match any combination the following patters: xxxxxxxxxx, xxx xxx xxxx, xxx-xxx-xxxx</small>
+								<small>A phone number can only contain numbers with dashes or spaces separating each group of numbers. Parenthesis are allowed around the begining three numbers. Example: (555) 555-5555</small>
 							</div>
 						</div>
 					</div>

--- a/src/assets/partials/forms/editForm.html
+++ b/src/assets/partials/forms/editForm.html
@@ -25,24 +25,19 @@
 							  		       editForm.first.$dirty"></span>
 						</span>
 					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row"
-		 ng-show="editForm.first.$invalid &&
-		 	      editForm.first.$dirty">
-		<div class="col-md-7 col-md-offset-5">
-			<div class="panel panel-xs panel-danger">
-				<div class="panel-heading panel-danger"
-					 ng-show="editForm.first.$error.required">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A first name is required.</small>
-				</div>
-				<div class="panel-heading panel-danger"
-					   ng-show="editForm.first.$error.maxlength">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A first name cannot be longer than 32 characters.</small>
+					<div class="panel panel-xs panel-danger"
+						 ng-show="editForm.first.$dirty && editForm.first.$invalid">
+						<div ng-messages="editForm.first.$error">
+							<div ng-message="required">
+								<span class="glyphicon glyphicon-exclamation-sign"></span>
+								<small>A first name is required</small>
+							</div>
+							<div ng-message="maxlength">
+								<span class="glyphicon glyphicon-exclamation-sign"></span>
+								<small>A first name cannot be longer than 32 charaters</small>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -73,24 +68,19 @@
 							  		       editForm.last.$dirty"></span>
 						</span>
 					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row"
-		 ng-show="editForm.last.$invalid &&
-		 	      editForm.last.$dirty">
-		<div class="col-md-7 col-md-offset-5">
-			<div class="panel panel-xs panel-danger">
-				<div class="panel-heading panel-danger"
-					 ng-show="editForm.last.$error.required">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A last name is required.</small>
-				</div>
-				<div class="panel-heading panel-danger"
-					   ng-show="editForm.last.$error.maxlength">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A last name cannot be longer than 32 characters.</small>
+					<div class="panel panel-xs panel-danger"
+						 ng-show="editForm.last.$dirty && editForm.last.$invalid">
+						<div ng-messages="editForm.last.$error">
+							<div ng-message="required">
+								<span class="glyphicon glyphicon-exclamation-sign"></span>
+								<small>A last name is required</small>
+							</div>
+							<div ng-message="maxlength">
+								<span class="glyphicon glyphicon-exclamation-sign"></span>
+								<small>A last name cannot be longer than 32 characters</small>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -112,8 +102,7 @@
 							   ng-model="modUser.phone"
 							   placeholder="{{user.phone}}" 
 							   required
-							   ng-minlength=10
-							   ng-maxlength=15>
+							   ng-pattern="/^\(?(\d{3})\)?[-|' ']?(\d{3})[-|' ']?(\d{4})$/">
 						<span class="input-group-addon input-addon">
 							<span class="glyphicon glyphicon-ok form-control-feedback input-glyphicon"
 								  ng-show="editForm.phone.$valid"></span>
@@ -122,39 +111,26 @@
 							  		       editForm.phone.$dirty"></span>
 						</span>
 					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row"
-		 ng-show="editForm.phone.$invalid &&
-		 	      editForm.phone.$dirty">
-		<div class="col-md-7 col-md-offset-5">
-			<div class="panel panel-xs panel-danger">
-				<div class="panel-heading panel-danger"
-					 ng-show="editForm.phone.$error.required">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A phone number is required.</small>
-				</div>
-				<div class="panel-heading panel-danger"
-					   ng-show="editForm.phone.$error.minlength">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A phone number cannot be less than 10 characters.</small>
-				</div>
-				<div class="panel-heading panel-danger"
-					   ng-show="editForm.phone.$error.maxlength">
-					<span class="glyphicon glyphicon-exclamation-sign"></span>
-					<small>A phone number cannot be longer than 15 characters.</small>
+					<div class="panel panel-xs panel-danger"
+						 ng-show="editForm.phone.$dirty && editForm.phone.$invalid">
+						<div ng-messages="editForm.phone.$error">
+							<div ng-message="required" class=>
+								<span class="glyphicon glyphicon-exclamation-sign"></span>
+								<small>An phone number is required.</small>
+							</div>
+							<div ng-message="pattern">
+								<span class="glyphicon glyphicon-exclamation-sign"></span>
+								<small>A phone number must match any combination the following patters: xxxxxxxxxx, xxx xxx xxxx, xxx-xxx-xxxx</small>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>
 	</div>
 	<div class="row">	
 		<div class="col-md-12">	
-			<div class="form-group"
-				 ng-class="{'has-success': editForm.email.$valid,
-				 			'has-error': editForm.email.$invalid &&
-				 						 editForm.email.$dirty}">	
+			<div class="form-group">	
 				<label for="email"
 					   class="col-md-5 form-label">Email Address:</label>
 				<div class="col-md-7">

--- a/src/assets/partials/forms/editForm.html
+++ b/src/assets/partials/forms/editForm.html
@@ -102,7 +102,7 @@
 							   name="phone"
 							   id="phone"
 							   ng-model="modUser.phone"
-							   placeholder="{{user.phone}}" 
+							   placeholder="{{'('+ user.phone.slice(0,3) + ') ' + user.phone.slice(3,6) + '-' + user.phone.slice(6,10)}}" 
 							   required
 							   ng-pattern="/^\(?(\d{3})\)?[-|' ']?(\d{3})[-|' ']?(\d{4})$/">
 						<span class="input-group-addon input-addon">

--- a/src/assets/partials/forms/newForm.html
+++ b/src/assets/partials/forms/newForm.html
@@ -27,7 +27,8 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="newForm.first.$dirty && newForm.first.$invalid">
-						<div ng-messages="newForm.first.$error">
+						<div ng-messages="newForm.first.$error"
+							 class="error-message">
 							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>A first name is required</small>
@@ -70,7 +71,8 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="newForm.last.$dirty && newForm.last.$invalid">
-						<div ng-messages="newForm.last.$error">
+						<div ng-messages="newForm.last.$error"
+							 class="error-message">
 							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>A last name is required</small>
@@ -113,14 +115,15 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="newForm.phone.$dirty && newForm.phone.$invalid">
-						<div ng-messages="newForm.phone.$error">
-							<div ng-message="required" class=>
+						<div ng-messages="newForm.phone.$error"
+							 class="error-message">
+							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>An phone number is required.</small>
 							</div>
 							<div ng-message="pattern">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
-								<small>A phone number must match any combination the following patters: xxxxxxxxxx, xxx xxx xxxx, xxx-xxx-xxxx</small>
+								<small>A phone number can only contain numbers with dashes or spaces separating each group of numbers. Parenthesis are allowed around the begining three numbers. Example: (555) 555-5555</small>
 							</div>
 						</div>
 					</div>
@@ -156,7 +159,8 @@
 					</div>
 					<div class="panel panel-xs panel-danger"
 						 ng-show="newForm.email.$dirty && newForm.email.$invalid">
-						<div ng-messages="newForm.email.$error">
+						<div ng-messages="newForm.email.$error"
+							 class="error-message">
 							<div ng-message="required">
 								<span class="glyphicon glyphicon-exclamation-sign"></span>
 								<small>An email address is required</small>

--- a/src/assets/partials/views/users.html
+++ b/src/assets/partials/views/users.html
@@ -93,7 +93,7 @@
 												<h5 class="panel-title">Phone</h5>
 											</div>
 											<div class="panel-body user-panel-body">
-												{{user.phone}}
+												{{'('+ user.phone.slice(0,3) + ') ' + user.phone.slice(3,6) + '-' + user.phone.slice(6,10)}}
 											</div>
 										</div>
 										<div class="panel panel-info"

--- a/src/assets/partials/views/users.profile.html
+++ b/src/assets/partials/views/users.profile.html
@@ -16,7 +16,7 @@
 						<h3 class="panel-title">Phone</h3>
 					</div>
 					<div class="panel-body">
-						{{user.phone}}
+						{{'('+ user.phone.slice(0,3) + ') ' + user.phone.slice(3,6) + '-' + user.phone.slice(6,10)}}
 					</div>
 				</div>
 			</div>

--- a/src/assets/scripts/controllers/usersController.js
+++ b/src/assets/scripts/controllers/usersController.js
@@ -9,7 +9,12 @@ app.controller('usersController', function($scope, $state, $modal, $log, userSer
 	this.userInfo = {phone: false,
 					 email: false};
 
+	$scope.cleanPhoneNumber = function(phoneNum) {
+		return phoneNum.replace(/\D/g,'');
+	}
+
 	$scope.addUser = function(user) {
+		user.phone = $scope.cleanPhoneNumber(user.phone);
 		userService.addUser(user);
 	};
 
@@ -18,12 +23,15 @@ app.controller('usersController', function($scope, $state, $modal, $log, userSer
 	};
 
 	$scope.editUser = function(user) {
+		user.phone = $scope.cleanPhoneNumber(user.phone);
 		userService.editUser(user);
 		userService.getUsers();
 	};
 
 	$scope.createEditUser = function() {
 		$scope.modUser = angular.copy($scope.user);
+		$scope.modUser.phone = '(' + $scope.modUser.phone.slice(0,3) + ') ' +
+								$scope.modUser.phone.slice(3,6) + '-' + $scope.modUser.phone.slice(6,10);
 	}
 
 	$scope.deleteUser = function(user) {


### PR DESCRIPTION
Edit form errors now identical to new form. Phone input on edit form now uses a regex pattern. Phone numbers saved to server stripped of non-numbers. When shown on webpage, all phone numbers are formatted to be uniform.
